### PR TITLE
Added auto-complete via React autosuggest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prop-types": "^15.6.1",
     "query-string": "^6.1.0",
     "react": "^16.4.1",
+    "react-autosuggest": "^9.3.4",
     "react-dom": "^16.4.1",
     "react-hot-loader": "^3.0.0-beta.1",
     "react-router": "^4.0.0-2",

--- a/server/services/arc_gis.js
+++ b/server/services/arc_gis.js
@@ -133,7 +133,7 @@ function getSuggestions (userValue) {
       text: userValue,
       countryCode: 'USA',
       category: 'Address,Postal,Populated Place',
-      maxSuggestions: 8,
+      maxSuggestions: 5,
       searchExtent: '-160.519409,17.940161,-153.949585,23.426046',
       f: 'pjson',
     })

--- a/server/services/arc_gis.js
+++ b/server/services/arc_gis.js
@@ -49,7 +49,7 @@ function getPrecincts() {
 }
 
 function getPrecinct(dp) {
-  // HI2016G_Precincts_HACC
+  // HI2018G_Precincts_HACC
   const baseUrl = 'https://services2.arcgis.com/tuFQUQg1xd48W6M5/arcgis/rest/services/PowerBallotHI2018P/FeatureServer/0/query'
 
   const result = SuperAgent.get(baseUrl)
@@ -125,9 +125,51 @@ function lookupPrecinct (coordinates, spatialReference) {
   })
 }
 
+function getSuggestions (userValue) {
+  const baseUrl = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest'
+
+  const result = SuperAgent.get(baseUrl)
+    .query({
+      text: userValue,
+      countryCode: 'USA',
+      category: 'Address,Postal,Populated Place',
+      maxSuggestions: 8,
+      searchExtent: '-160.519409,17.940161,-153.949585,23.426046',
+      f: 'pjson',
+    })
+
+    // { text: 'predictedValue', magicKey: 'keyForNextLookup' }
+
+  return result.then((data) => {
+    return JSON.parse(data.text).suggestions
+  })
+}
+
+function geocodeFromMagicKey (magicKey) {
+  const baseUrl = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates'
+
+  const result = SuperAgent.get(baseUrl)
+    .query({
+      outSR: { wkid: 4326 },
+      outFields: 'Match_addr,stAddr,City',
+      magicKey: magicKey,
+      maxLocations: 3,
+      f: 'json',
+    })
+
+  return result.then((data) => {
+    console.log('got data')
+    return JSON.parse(data.text)
+  }).catch((reason) => {
+    console.log("unable to fetch", reason)
+  })
+}
+
 module.exports = {
   geocodeAddress,
+  geocodeFromMagicKey,
   getPrecinct,
   getContests,
   lookupPrecinct,
+  getSuggestions,
 }

--- a/src/components/home/FindYourBallot.jsx
+++ b/src/components/home/FindYourBallot.jsx
@@ -78,19 +78,6 @@ export default class FindYourBallot extends React.Component {
             Find <i>Your</i>&nbsp; “Power Ballot”
           </div>
           <div className={styles['input-container']}>
-            <input
-              className={styles['input']}
-              type='text'
-              placeholder="Type your address (street address, city, state, zip) here to get YOUR Power Ballot"
-              onChange={onChange}
-              onKeyPress={onKeyPress}
-              value={value}
-            />
-            <div className={styles['go-button']} onClick={onSubmitHandler}>
-              GO
-            </div>
-          </div>
-          <div className={styles['input-container']}>
             <Autosuggest
               suggestions={suggestions}
               onSuggestionsFetchRequested={this._onSuggestionsFetchRequested}

--- a/src/components/home/FindYourBallot.jsx
+++ b/src/components/home/FindYourBallot.jsx
@@ -1,11 +1,75 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Autosuggest from 'react-autosuggest'
+
+// eslint-disable-next-line import/named
+import { getSuggestions } from 'server/services/arc_gis'
+
 import styles from './find-your-ballot.scss'
 
 export default class FindYourBallot extends React.Component {
+
+  state = {
+    suggestions: [],
+    debouncing: false,
+  }
+
+  _getSuggestions = (address) => {
+    const { debouncing } = this.state
+
+    // Reset the debounce timer if it is already in the process
+    if (debouncing) {
+      clearTimeout(debouncing)
+      this.setState({debouncing: false})
+    }
+
+    if (!!address) {
+      const currentTimeout = setTimeout(() => {
+        getSuggestions(address).then((result) => {
+          this.setState({
+            suggestions: result,
+            debouncing: false,
+          })
+        })
+      }, 200)
+
+      this.setState({debouncing: currentTimeout})
+    }
+  }
+
+  _getSuggestionValue = suggestion => {
+    return suggestion.text
+  }
+
+  // Use your imagination to render suggestions.
+  _renderSuggestion = suggestion => (
+    <div className={styles['suggestion']}>
+      {suggestion.text}
+    </div>
+  )
+
+  _onSuggestionsFetchRequested = ({ value }) => {
+    this._getSuggestions(value)
+  }
+
+  _onSuggestionsClearRequested = () => {
+    this.setState({
+      suggestions: [],
+    })
+  }
+
   render () {
-    const { fetching, onChange, onKeyPress, value, onSubmitHandler } = this.props
+    const { fetching, onChange, onKeyPress, value, onSubmitHandler, onSuggestionSelected } = this.props
+    const { suggestions } = this.state
+
+    // Autosuggest will pass through all these props to the input.
+    const inputProps = {
+      placeholder: 'Type your address (street address, city, state, zip) here to get YOUR Power Ballot',
+      value: value,
+      onChange: onChange,
+      onKeyPress: onKeyPress,
+    }
 
     return (
       <div className={styles['container']}>
@@ -21,6 +85,20 @@ export default class FindYourBallot extends React.Component {
               onChange={onChange}
               onKeyPress={onKeyPress}
               value={value}
+            />
+            <div className={styles['go-button']} onClick={onSubmitHandler}>
+              GO
+            </div>
+          </div>
+          <div className={styles['input-container']}>
+            <Autosuggest
+              suggestions={suggestions}
+              onSuggestionsFetchRequested={this._onSuggestionsFetchRequested}
+              onSuggestionsClearRequested={this._onSuggestionsClearRequested}
+              onSuggestionSelected={onSuggestionSelected}
+              getSuggestionValue={this._getSuggestionValue}
+              renderSuggestion={this._renderSuggestion}
+              inputProps={inputProps}
             />
             <div className={styles['go-button']} onClick={onSubmitHandler}>
               GO
@@ -42,4 +120,5 @@ FindYourBallot.propTypes = {
   onKeyPress: PropTypes.func,
   value: PropTypes.string,
   onSubmitHandler: PropTypes.func,
+  onSuggestionSelected: PropTypes.func,
 }

--- a/src/components/home/find-your-ballot.scss
+++ b/src/components/home/find-your-ballot.scss
@@ -41,3 +41,61 @@ $input-padding: 12px;
   margin-top: 15px;
   font-style: italic;
 }
+
+:global {
+
+  .react-autosuggest__container {
+    display: flex;
+    flex: 1;
+    position: relative;
+  }
+
+  .react-autosuggest__input {
+    display: inline-block;
+    flex: 1;
+    flex-basis: 350px;
+    outline: none;
+    padding: $input-padding;
+  }
+
+  .react-autosuggest__input--focused {
+    outline: none;
+  }
+
+  .react-autosuggest__input--open {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .react-autosuggest__suggestions-container {
+    display: none;
+  }
+
+  .react-autosuggest__suggestions-container--open {
+    display: block;
+    position: absolute;
+    top: 51px;
+    flex: 1;
+    border: 1px solid $medium-grey;
+    background-color: $white;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2;
+  }
+
+  .react-autosuggest__suggestions-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    color: $black
+  }
+
+  .react-autosuggest__suggestion {
+    cursor: pointer;
+    padding: $input-padding;
+  }
+
+  .react-autosuggest__suggestion--highlighted {
+    background-color: $light-grey;
+  }
+}

--- a/src/components/home/find-your-ballot.scss
+++ b/src/components/home/find-your-ballot.scss
@@ -42,60 +42,62 @@ $input-padding: 12px;
   font-style: italic;
 }
 
-:global {
+.container {
+  :global {
+    .react-autosuggest__container {
+      display: flex;
+      flex: 1;
+      position: relative;
+    }
 
-  .react-autosuggest__container {
-    display: flex;
-    flex: 1;
-    position: relative;
-  }
+    .react-autosuggest__input {
+      display: inline-block;
+      flex: 1;
+      flex-basis: 350px;
+      outline: none;
+      padding: $input-padding;
+    }
 
-  .react-autosuggest__input {
-    display: inline-block;
-    flex: 1;
-    flex-basis: 350px;
-    outline: none;
-    padding: $input-padding;
-  }
+    .react-autosuggest__input--focused {
+      outline: none;
+    }
 
-  .react-autosuggest__input--focused {
-    outline: none;
-  }
+    .react-autosuggest__input--open {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
 
-  .react-autosuggest__input--open {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
+    .react-autosuggest__suggestions-container {
+      width: 100%;
+      display: none;
+    }
 
-  .react-autosuggest__suggestions-container {
-    display: none;
-  }
+    .react-autosuggest__suggestions-container--open {
+      display: block;
+      position: absolute;
+      top: 100%;
+      flex: 1;
+      border: 1px solid $medium-grey;
+      background-color: $white;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      z-index: 2;
+    }
 
-  .react-autosuggest__suggestions-container--open {
-    display: block;
-    position: absolute;
-    top: 51px;
-    flex: 1;
-    border: 1px solid $medium-grey;
-    background-color: $white;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    z-index: 2;
-  }
+    .react-autosuggest__suggestions-list {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
+      color: $black
+    }
 
-  .react-autosuggest__suggestions-list {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-    color: $black
-  }
+    .react-autosuggest__suggestion {
+      cursor: pointer;
+      padding: $input-padding;
+    }
 
-  .react-autosuggest__suggestion {
-    cursor: pointer;
-    padding: $input-padding;
-  }
-
-  .react-autosuggest__suggestion--highlighted {
-    background-color: $light-grey;
+    .react-autosuggest__suggestion--highlighted {
+      background-color: $light-grey;
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,6 +4401,10 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -5257,6 +5261,13 @@ promise@~2.0:
   dependencies:
     is-promise "~1"
 
+prop-types@^15.5.10, prop-types@^15.5.8:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -5400,6 +5411,22 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autosuggest@^9.3.4:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.4.tgz#e47ff800081b2f7c678165bfb7cc84b07f462336"
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.0"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.1.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.1.2.tgz#200ffc41373b2189e3f6140ac7bdb82363a79fd3"
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
@@ -5451,6 +5478,12 @@ react-router@^4.0.0-2, react-router@^4.3.1:
     path-to-regexp "^1.7.0"
     prop-types "^15.6.1"
     warning "^4.0.1"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  dependencies:
+    object-assign "^3.0.0"
 
 react@^16.4.1:
   version "16.4.1"
@@ -5859,6 +5892,10 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -5950,6 +5987,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
https://github.com/moroshko/react-autosuggest

Added the library via the `yarn` guide on their page.

I arbitrarily chose 8 for the suggestion size, we could probably adjust it (and I might just set it to 5). If the user used the suggestion it will use the `magicKey`, otherwise it will fall back to the traditional look up approach. It looks like you improved this recently so "Honolulu" will work, which is cool. 

Using the "enter" key when in the suggestion box will select AND search, as opposed to clicking on it manually. Not sure if we want to do anything about this but I think it's fine.

The styling I couldn't figure out how to properly do, so I hacked it with a `:global` but it would be good if you could potentially figure out/fix this and let me know how you did it since I tried a couple different nesting options/approaches but it didn't seem to work for me.